### PR TITLE
Inactive highlight

### DIFF
--- a/glacier.tmTheme
+++ b/glacier.tmTheme
@@ -26,7 +26,7 @@
                 <key>findHighlight</key>
                 <string>#5eebb8</string>
                 <key>inactiveSelection</key>
-                <string>#1b2731</string>
+                <string>#23323f</string>
                 <key>gutter</key>
                 <string>#0c1217</string>
                 <key>gutterForeground</key>


### PR DESCRIPTION
A much more subtle inactive highlight colour:

![screen shot 2014-06-05 at 14 48 11](https://cloud.githubusercontent.com/assets/760314/3188189/5e396aa0-ecb8-11e3-9a4c-4a65b35356f4.png)

For original bight green see: https://github.com/joeyfigaro/glacier-theme/issues/8
