### PR TITLE
Fix #16 - Add widget theme files to support custom console background

### DIFF
--- a/Glacier.sublime-theme
+++ b/Glacier.sublime-theme
@@ -756,8 +756,7 @@
     {
         "class": "text_line_control",
         "layer0.texture": "",
-        // "layer0.tint": [118, 255, 205],
-        "layer0.tint": [230, 230, 230],
+        "layer0.tint": [7,11,14],
         "layer0.opacity": 1,
         "content_margin": [5,7,0,5]
     },

--- a/Glacier/Widget - Glacier.stTheme
+++ b/Glacier/Widget - Glacier.stTheme
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+        <string>#070b0e</string>
+        <key>caret</key>
+        <string>#ffe792</string>
+        <key>foreground</key>
+        <string>#efefef</string>
+        <key>invisibles</key>
+        <string>#F3FFB51A</string>
+        <key>selection</key>
+        <string>#bd4230</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist<name /<name />

--- a/Glacier/Widget - Glacier.sublime-settings
+++ b/Glacier/Widget - Glacier.sublime-settings
@@ -1,0 +1,4 @@
+{
+    "color_scheme": "Packages/Theme - Glacier/Glacier/Widget - Glacier.stTheme",
+    "draw_shadows": false
+}


### PR DESCRIPTION
Based on the files in the [Spacegray theme](https://github.com/kkga/spacegray) I created widget files to set the background for the console, this also has the side effect of changing the background for text inputs. I couldn't find a way to override this for text inputs, so I adjusted the background of the text inputs to be the same dark blue that is used for the background of the find/replace panel, this is also what Spacegray does.

![screen shot 2014-08-12 at 10 10 24 am](https://cloud.githubusercontent.com/assets/82437/3891482/6fe6e0d2-222a-11e4-9b6a-ba1b95713b23.png)
