### PR TITLE
Fix shovelandsandbox/glacier-theme#38 by making active guide yellow

### DIFF
--- a/colors/color-conversion.md
+++ b/colors/color-conversion.md
@@ -23,3 +23,30 @@ yellow-light-1    F7F09D          hsl( 55,  85%,  79%) 10x
 yellow-light-2    B3AC6A          hsl( 54,  32%,  56%) 0x
 
 ----
+
+New Colors (Honiix):
+
+black-1:          0E141B    hsl(210,  32%,   8%)
+black-2:          070A0D    hsl(210,  32%,   4%)
+blue-bright-1:    3CAED7    hsl(196,  66%,  54%)
+blue-bright-2:    266D87    hsl(196,  56%,  34%)
+blue-dark-1:      30475F    hsl(210,  33%,  28%)
+blue-dark-2:      18242F    hsl(210,  33%,  14%)
+blue-pale-1:      AEC4DB    hsl(211,  38%,  77%)
+blue-pale-2:      8A96A8    hsl(215,  15%,  60%)
+green-bright-1:   75FFCD    hsl(158,  100%, 73%)
+green-bright-2:   4BBE96    hsl(159,  47%,  52%)
+grey-bright-1:    B0B3BA    hsl(222,   7%,  71%)
+grey-bright-2:    515B67    hsl(211,  12%,  36%)
+orange-bright-1:  FFB452    hsl( 34, 100%,  66%)
+orange-bright-2:  F57542    hsl( 17,  90%,  61%)
+pink-bright-1:    D64379    hsl(338,  64%,  55%)
+pink-bright-2:    A40E45    hsl(338,  84%,  35%)
+purple-bright-1:  BF33C7    hsl(297,  59%,  49%)
+purple-bright-2:  78217D    hsl(297,  58%,  31%)
+red-bright-1:     F04242    hsl(0,    85%,  60%)
+red-bright-2:     A12626    hsl(0,    62%,  39%)
+white-1:          FAFAFA    hsl(  0,   0%,  98%)
+white-2:          E6E6E6    hsl(  0,   0%,  90%)
+yellow-bright-1:  F7EF9C    hsl( 55,  85%,  79%)
+yellow-bright-2:  B3AC6B    hsl( 54,  32%,  56%)

--- a/glacier.sublime-color-scheme
+++ b/glacier.sublime-color-scheme
@@ -29,7 +29,7 @@
   },
   "globals": {
     "accent":                        "var(green-bright-2)",
-    "active_guide":                  "color(var(blue-dark-1) a(0.69))",
+    "active_guide":                  "color(var(yellow-bright-2) a(0.5))",
     "background":                    "var(black-1)",
     "block_caret":                   "color(var(yellow-bright-1) a(0.4))",
     "bracket_contents_foreground":   "var(white-1)",
@@ -63,7 +63,7 @@
     "selection_foreground":          "var(white-1)",
     "shadow":                        "var(yellow-bright-1)",
     "shadow_width":                  "3",
-    "stack_guide":                   "color(var(blue-dark-2) a(0.69))",
+    "stack_guide":                   "color(var(blue-dark-1) a(0.5))",
     "tags_foreground":               "var(yellow-bright-1)",
     "tags_options":                  "stippled_underline"
   },


### PR DESCRIPTION
So the active guide is differentiated from normal guide.